### PR TITLE
Found a duplicate class styling and removed it

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -100,15 +100,6 @@ p {
     margin-left: 25px;
 }
 
-.image-left-article {
-    margin-bottom: 20px;
-    padding: 50px;
-    height: 300px;
-    font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
-    background-color: #0072bb;
-    color: #ffffff;
-}
-
 .benefits {
     margin-right: 20px;
     padding: 20px;


### PR DESCRIPTION
Found a duplicate of the .image-left-article styling and removed it. This was left over from combining redundant classes.